### PR TITLE
fix '>' and '<' not working in inline math env.

### DIFF
--- a/markdown-plus.js
+++ b/markdown-plus.js
@@ -256,7 +256,8 @@ $(document).ready(function() {
   };
   renderer.codespan = function(text) { // inline code
     if(/^\$.+\$$/.test(text)) { // inline math
-      var line = /^\$(.+)\$$/.exec(text)[1];
+      var raw = /^\$(.+)\$$/.exec(text)[1];
+      var line = raw.replace(/&lt;/g,'<').replace(/&gt;/g,'>') // replace '&lt;' and '&gt;'
       try{
         return katex.renderToString(line, { displayMode: false });
       } catch(err) {


### PR DESCRIPTION
Math inline environment not support '>' and '<' symbols.

Test:
`$x > y$`
Return:
<code>ParseError: KaTeX parse error: Unexpected character: '&' at position 0: ̲> </code>

Fix it by replacing '&gt;' and '&lt;' by '>' and '<' before passing text into **katex**. 

Also, the mac version markdown plus has the same problem. 
