### PR TITLE
修改示例中的 i 标签

### DIFF
--- a/sample.md
+++ b/sample.md
@@ -6,7 +6,7 @@ Markdown Plus ("M+" or "mdp" for short) is a versatile markdown editor. Besides 
 
 ##### Fork me on GitHub: <i class="fa fa-github" style="font-size: 64px;"/> [tylingsoft/markdown-plus](https://github.com/tylingsoft/markdown-plus).
 
-##### Buy our Mac app: <i class="fa fa-apple" style="font-size: 64px;"/> [tylingsoft.com/mdp](https://tylingsoft.com/mdp)
+##### Buy our Mac app: <i class="fa fa-apple" style="font-size: 64px;"></i> [tylingsoft.com/mdp](https://tylingsoft.com/mdp)
 
 ---
 
@@ -64,24 +64,24 @@ Function name | Description
 
 ## Font Awesome icons
 
-<i class="fa fa-cloud" style="font-size: 64px;"/>
-<i class="fa fa-flag" style="font-size: 64px;"/>
-<i class="fa fa-car" style="font-size: 64px;"/>
-<i class="fa fa-truck" style="font-size: 64px;"/>
-<i class="fa fa-heart" style="font-size: 64px;"/>
-<i class="fa fa-dollar" style="font-size: 64px;"/>
+<i class="fa fa-cloud" style="font-size: 64px;"></i>
+<i class="fa fa-flag" style="font-size: 64px;"></i>
+<i class="fa fa-car" style="font-size: 64px;"></i>
+<i class="fa fa-truck" style="font-size: 64px;"></i>
+<i class="fa fa-heart" style="font-size: 64px;"></i>
+<i class="fa fa-dollar" style="font-size: 64px;"></i>
 
 [All the Font Awesome icons](http://fontawesome.io/icons/)
 
 
 ## Ionicons icons
 
-<i class="icon ion-beer" style="font-size: 88px;"/>
-<i class="icon ion-key" style="font-size: 88px;"/>
-<i class="icon ion-locked" style="font-size: 88px;"/>
-<i class="icon ion-location" style="font-size: 88px;"/>
-<i class="icon ion-plane" style="font-size: 88px;"/>
-<i class="icon ion-ios-eye" style="font-size: 88px;"/>
+<i class="icon ion-beer" style="font-size: 88px;"></i>
+<i class="icon ion-key" style="font-size: 88px;"></i>
+<i class="icon ion-locked" style="font-size: 88px;"></i>
+<i class="icon ion-location" style="font-size: 88px;"></i>
+<i class="icon ion-plane" style="font-size: 88px;"></i>
+<i class="icon ion-ios-eye" style="font-size: 88px;"></i>
 
 [All the Ionicons icons](http://ionicons.com/)
 


### PR DESCRIPTION
i 标签貌似无法自己闭合吧，在其他 markdown 编辑器下都是乱的
